### PR TITLE
Fix installation from pypi, README.md wasn't included

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Hello,

Installation from pypi results in:

```
Collecting html2hamlpy
  Downloading html2hamlpy-0.11.3.tar.gz
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-m3qWJA/html2hamlpy/setup.py", line 20, in <module>
        long_description = open("README.md").read(),
    IOError: [Errno 2] No such file or directory: 'README.md'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

      File "<string>", line 20, in <module>

      File "/tmp/pip-build-m3qWJA/html2hamlpy/setup.py", line 20, in <module>

        long_description = open("README.md").read(),

    IOError: [Errno 2] No such file or directory: 'README.md'

    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-m3qWJA/html2hamlpy
```

Adding a MANIFEST.in fix that, but you'll have to re-upload to pypi.

Cheers,
