### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![Build Status](http://img.shields.io/travis/davidtingsu/html2hamlpy/master.svg)](https://travis-ci.org/davidtingsu/html2hamlpy?branch=master)
 [![Coverage Status](http://img.shields.io/coveralls/davidtingsu/html2hamlpy/master.svg)](https://coveralls.io/r/davidtingsu/html2hamlpy?branch=master)
-[![Latest Version](https://img.shields.io/pypi/v/html2hamlpy.svg
-[![Downloads](https://img.shields.io/pypi/dm/html2hamlpy.svg
-[![License](https://img.shields.io/pypi/l/html2hamlpy.svg
+[![Latest Version](https://img.shields.io/pypi/v/html2hamlpy.svg)](https://pypi.python.org/pypi/html2hamlpy/)
+[![License](https://img.shields.io/pypi/l/html2hamlpy.svg)](https://pypi.python.org/pypi/html2hamlpy/)
 html2hamlpy
 =======
 Converts HTML to [HamlPy](https://github.com/jessemiller/HamlPy)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build Status](http://img.shields.io/travis/davidtingsu/html2hamlpy/master.svg)](https://travis-ci.org/davidtingsu/html2hamlpy?branch=master)
 [![Coverage Status](http://img.shields.io/coveralls/davidtingsu/html2hamlpy/master.svg)](https://coveralls.io/r/davidtingsu/html2hamlpy?branch=master)
-[![Latest Version](https://pypip.in/version/html2hamlpy/badge.svg)](https://pypi.python.org/pypi/html2hamlpy/)
-[![Downloads](https://pypip.in/d/html2hamlpy/badge.svg)](https://pypi.python.org/pypi/html2hamlpy/)
-[![License](https://pypip.in/license/html2hamlpy/badge.svg)](https://pypi.python.org/pypi/html2hamlpy/)
+[![Latest Version](https://img.shields.io/pypi/v/html2hamlpy.svg
+[![Downloads](https://img.shields.io/pypi/dm/html2hamlpy.svg
+[![License](https://img.shields.io/pypi/l/html2hamlpy.svg
 html2hamlpy
 =======
 Converts HTML to [HamlPy](https://github.com/jessemiller/HamlPy)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20html2hamlpy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `html2hamlpy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.